### PR TITLE
[#606] Added support for NPM assets packages for libraries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "drupal/stage_file_proxy": "^1.1",
         "drupal/token": "^1.7",
         "drush/drush": "^10",
+        "oomphinc/composer-installers-extender": "^2.0",
         "vlucas/phpdotenv": "^5.1",
         "webflo/drupal-finder": "^1.2",
         "zaporylie/composer-drupal-optimizations": "^1.2"
@@ -57,6 +58,10 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "asset-packagist": {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     },
     "scripts": {
@@ -102,7 +107,9 @@
                 "type:drupal-core"
             ],
             "docroot/libraries/{$name}": [
-                "type:drupal-library"
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
             ],
             "docroot/modules/contrib/{$name}": [
                 "type:drupal-module"
@@ -117,6 +124,10 @@
                 "type:drupal-drush"
             ]
         },
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
         "preserve-paths": [
             "docroot/modules/custom",
             "docroot/themes/custom",


### PR DESCRIPTION
Example
"npm-asset/select2": "^4.0"

closes #606 