### PR TITLE
[9.x] Added composer cmd to ahoy.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -84,6 +84,9 @@ commands:
     #: The shell is started if no arguments were provided to this command.
     cmd: if \[ "${#}" -ne 0 \]; then docker-compose exec -T cli bash -c "$*"; else docker-compose exec cli bash; fi
 
+  composer:
+    usage: Run composer commands in the CLI service container.
+    cmd: docker-compose exec -T cli composer "$@"
   drush:
     usage: Run drush commands in the CLI service container.
     cmd: docker-compose exec -T cli drush -l ${LOCALDEV_URL} "$@"

--- a/scripts/drevops/tests/bats/_helper_drevops_workflow.bash
+++ b/scripts/drevops/tests/bats/_helper_drevops_workflow.bash
@@ -222,6 +222,15 @@ assert_env_changes() {
   assert_output_not_contains "my_custom_var_value"
 }
 
+assert_ahoy_composer() {
+  step "Run composer command"
+
+  run ahoy composer about
+  assert_success
+  assert_output_contains "Composer - Dependency Manager for PHP - version 2."
+  assert_output_contains "Composer is a dependency manager tracking local dependencies of your projects and libraries."
+}
+
 assert_ahoy_drush() {
   step "Run Drush command"
 

--- a/scripts/drevops/tests/bats/workflow0.bats
+++ b/scripts/drevops/tests/bats/workflow0.bats
@@ -22,6 +22,8 @@ load _helper_drevops_workflow
 
   assert_env_changes
 
+  assert_ahoy_composer
+
   assert_ahoy_drush
 
   assert_ahoy_info
@@ -68,6 +70,8 @@ load _helper_drevops_workflow
   assert_gitignore
 
   assert_ahoy_cli
+
+  assert_ahoy_composer
 
   assert_ahoy_drush
 


### PR DESCRIPTION
# Background

I have added  `ahoy composer` many times without the `ahoy cli composer`, this PR adds composer as a first class ahoy command.

## What has changed
1. Added `composer` command.
2. Added tests to ensure it is running correctly.