### PR TITLE
feat: Added support for tags in tests.

### DIFF
--- a/scripts/drevops/docs/mkdocs.yml
+++ b/scripts/drevops/docs/mkdocs.yml
@@ -100,5 +100,6 @@ nav:
   - Docker: docker.md
   - Database: database.md
   - Build: build.md
+  - Test: test.md
   - Deployment: docs/DEPLOYMENT.md
   - Maintenance: maintenance.md

--- a/scripts/drevops/docs/test.md
+++ b/scripts/drevops/docs/test.md
@@ -1,0 +1,140 @@
+# Test
+
+DrevOps supports running PHPUnit and Behat tests.
+
+It uses a wrapper script [test.sh](../test.sh) to proxy calls and support custom
+workflows.
+
+This script is wrapped with several Ahoy commands for simplicity of use.
+
+Entrypoint command is
+
+    ahoy test
+
+There are also per-test type commands:
+
+    ahoy test-unit
+
+    ahoy test-kernel
+
+    ahoy test-functional
+
+    ahoy test-bdd
+
+The type of tests can be overwritten by setting an environment variable
+`DREVOPS_TEST_TYPE` to hyphen-delimited test type value: `unit-kernel-functional-bdd`.
+
+Running of all tests can be skipped by setting `DREVOPS_TEST_SKIP` variable to `1`.
+
+## PHPUnit
+
+DrevOps uses Drupal core's `core/phpunit.xml.dist` PHPUnit configuration by
+default. This is done to benefit from the upstream test bootstrap process. The
+configuration file for every suite is specified in `DREVOPS_TEST_<SUITE>_CONFIG`
+variable and may be overridden.
+
+At the same time, consumer sites would not want to run core and contrib tests so
+DrevOps provides a mechanism to only execute tests from the site's custom
+modules and themes.
+
+To make the test discoverable, it has to have `@group site:<suite_type>` annotation:
+
+```php
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+/**
+ * Class YsCoreExampleUnitTest.
+ *
+ * Example test case class.
+ *
+ * @group site:unit
+ */
+class YsCoreExampleUnitTest extends YsCoreUnitTestBase {
+...
+}
+```
+
+This approach is more flexible than filtering file by name using the suite
+suffix (`*Unit*`, `*Kernel*`, `*Functional*` etc.) or supporting a custom
+suit class discovery service.
+
+In addition, the groups are controlled via the `DREVOPS_TEST_<SUITE>_GROUP`
+environment variables, allowing to override specific test group when needed
+without changing the code, for example, when need to isolate test runs in CI.
+These variables have default value of `site:<suite>`.
+
+### Reporting
+
+Test reports produced if `DREVOPS_TEST_REPORTS_DIR` is set. They are stored in
+`$DREVOPS_TEST_REPORTS_DIR/phpunit` directory separated into multiple files
+and named after the suite name. These reports are usually used in CI to track
+tests performance and stability.
+
+## Behat
+
+DrevOps provides full Behat support, including configuration in [behat.yml](behat.yml)
+and a [browser container](docker-compose.yml) to run interactive tests.
+
+It also provides additional configuration:
+
+1. DrupalExtension - an extension to work with Drupal.
+2. Behat steps - a library of re-usable Behat steps designed for working with Drupal.
+2. Screenshot extension - extension to capture screenshots on-demand and on failure.
+3. Progress formatter - extension to show progress as TAP and fails inline.
+4. Parallel profiles - configuration to allow running tests in parallel.
+
+### Profiles
+
+Behat `default` profile configured with sensible defaults to allow running Behat
+with Drupal extension.
+
+The profile can be overridden using `DREVOPS_TEST_BEHAT_PROFILE` environment variable.
+
+### Skipping tests
+
+Add `@skipped` tag to failing tests if you would like to skip them.
+
+### Parallel runs
+
+In CI, Behat tests can be tagged to be split between multiple runners. The tags
+are then used by profiles with the identical names to run them.
+
+Out of the box, DrevOps provides support for unlimited parallel runners, but only
+2 parallel profiles `p0` and `p1`: a feature can be tagged by either `p0` or `p1`
+to run in a dedicated runner, or with both tags to run in both runners. Note that
+you can easily add more `p*` profiles in your `behat.yml` by copying existing `p1`
+profile and changing several lines.
+
+Untagged feature will always run in the first runner.
+
+If CI has only one runner - a `default` profile will be used and all tests
+(except for those that tagged with `skipped`) will be run.
+
+### Screenshots
+
+Test screenshots are stored into `tests/behat/screenshots` location by default,
+which can be overwritten using `BEHAT_SCREENSHOT_DIR` variable (courtesy of
+`drevops/behat-screenshot` package). In CI, screenshots are stored as artifacts.
+
+### Format
+
+Out of the box, DrevOps comes with `drevops/behat-format-progress-fail` Behat
+output formatter to show progress as TAP and fails inline. This allows to
+continue test runs after failures while maintaining a minimal output.
+
+The format can be controlled `DREVOPS_TEST_BEHAT_FORMAT` environment variable.
+
+### Reporting
+
+Test reports produced if `DREVOPS_TEST_REPORTS_DIR` is set. They are stored in
+`$DREVOPS_TEST_REPORTS_DIR/behat` directory. These reports are usually used in
+CI to track tests performance and stability.
+
+### FeatureContext
+
+The [FeatureContext.php](tests/behat/FeatureContext.php) file comes with included
+steps from `drevops/behat-steps` package.
+
+Custom steps can be added into this file.

--- a/scripts/drevops/installer/install.php
+++ b/scripts/drevops/installer/install.php
@@ -454,8 +454,9 @@ function process__preserve_renovatebot($dir) {
 function process__string_tokens($dir) {
   $machine_name_hyphenated = str_replace('_', '-', get_answer('machine_name'));
   $machine_name_camel_cased = to_camel_case(get_answer('machine_name'), TRUE);
-  $module_prefix_capitalised = to_camel_case(get_answer('module_prefix'), TRUE);
-  $module_prefix_uppercase = strtoupper($module_prefix_capitalised);
+  $module_prefix_camel_cased = to_camel_case(get_answer('module_prefix'), TRUE);
+  $module_prefix_uppercase = strtoupper($module_prefix_camel_cased);
+  $theme_camel_cased = to_camel_case(get_answer('theme'), TRUE);
   $drevops_version_urlencoded = str_replace('-', '--', get_config('DREVOPS_VERSION'));
 
   $webroot = get_answer('webroot');
@@ -464,27 +465,29 @@ function process__string_tokens($dir) {
   // phpcs:disable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma
   // phpcs:disable Drupal.WhiteSpace.Comma.TooManySpaces
   dir_replace_content('your_site_theme',       get_answer('theme'),                      $dir);
+  dir_replace_content('YourSiteTheme',         $theme_camel_cased,                       $dir);
   dir_replace_content('your_org',              get_answer('org_machine_name'),           $dir);
   dir_replace_content('YOURORG',               get_answer('org'),                        $dir);
   dir_replace_content('your-site-url.example', get_answer('url'),                        $dir);
   dir_replace_content('ys_core',               get_answer('module_prefix') . '_core',    $dir . "/{$webroot}/modules/custom");
   dir_replace_content('ys_core',               get_answer('module_prefix') . '_core',    $dir . '/scripts/custom');
-  dir_replace_content('YsCore',                $module_prefix_capitalised . 'Core',      $dir . "/{$webroot}/modules/custom");
+  dir_replace_content('YsCore',                $module_prefix_camel_cased . 'Core',      $dir . "/{$webroot}/modules/custom");
   dir_replace_content('YSCODE',                $module_prefix_uppercase,                 $dir);
   dir_replace_content('your-site',             $machine_name_hyphenated,                 $dir);
   dir_replace_content('your_site',             get_answer('machine_name'),               $dir);
   dir_replace_content('YOURSITE',              get_answer('name'),                       $dir);
   dir_replace_content('YourSite',              $machine_name_camel_cased,                $dir);
-  replace_string_filename('YourSite',          $machine_name_camel_cased,                $dir);
+
+  replace_string_filename('YourSiteTheme',     $theme_camel_cased,                    $dir);
+  replace_string_filename('your_site_theme',   get_answer('theme'),                   $dir);
+  replace_string_filename('YourSite',          $machine_name_camel_cased,             $dir);
+  replace_string_filename('ys_core',           get_answer('module_prefix') . '_core', $dir . "/{$webroot}/modules/custom");
+  replace_string_filename('YsCore',            $module_prefix_camel_cased . 'Core',   $dir . "/{$webroot}/modules/custom");
+  replace_string_filename('your_org',          get_answer('org_machine_name'),        $dir);
+  replace_string_filename('your_site',         get_answer('machine_name'),            $dir);
 
   dir_replace_content('DREVOPS_VERSION_URLENCODED', $drevops_version_urlencoded,    $dir);
   dir_replace_content('DREVOPS_VERSION',            get_config('DREVOPS_VERSION'),  $dir);
-
-  replace_string_filename('your_site_theme',   get_answer('theme'),                   $dir);
-  replace_string_filename('ys_core',           get_answer('module_prefix') . '_core', $dir . "/{$webroot}/modules/custom");
-  replace_string_filename('YsCore',            $module_prefix_capitalised . 'Core',   $dir . "/{$webroot}/modules/custom");
-  replace_string_filename('your_org',          get_answer('org_machine_name'),        $dir);
-  replace_string_filename('your_site',         get_answer('machine_name'),            $dir);
   // @formatter:on
   // phpcs:enable Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma
   // phpcs:enable Drupal.WhiteSpace.Comma.TooManySpaces

--- a/scripts/drevops/test.sh
+++ b/scripts/drevops/test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2015
 ##
 # Run tests.
 #
@@ -21,9 +20,17 @@
 #
 # Run specific tags (eg: content_type) bdd tests:
 # DREVOPS_TEST_TYPE=bdd DREVOPS_TEST_BEHAT_TAGS=content_type ./test.sh
+#
+# shellcheck disable=SC2015
 
 set -e
 [ -n "${DREVOPS_DEBUG}" ] && set -x
+
+# Path to the root of the project inside the container.
+DREVOPS_APP=/app
+
+# Name of the webroot directory with Drupal installation.
+DREVOPS_WEBROOT="${DREVOPS_WEBROOT:-web}"
 
 # Flag to skip running of all tests.
 # Helpful to set in CI to skip running of tests without modifying the codebase.
@@ -32,20 +39,29 @@ DREVOPS_TEST_SKIP="${DREVOPS_TEST_SKIP:-}"
 # Flag to allow Unit tests to fail.
 DREVOPS_TEST_UNIT_ALLOW_FAILURE="${DREVOPS_TEST_UNIT_ALLOW_FAILURE:-0}"
 
-# Unit test group. Optional. Default runs all tests.
-DREVOPS_TEST_UNIT_GROUP="${DREVOPS_TEST_UNIT_GROUP:-}"
+# Unit test group. Optional. Defaults to running Unit tests tagged with `site:unit`.
+DREVOPS_TEST_UNIT_GROUP="${DREVOPS_TEST_UNIT_GROUP:-site:unit}"
+
+# Unit test configuration file. Optional. Defaults to core's configuration.
+DREVOPS_TEST_UNIT_CONFIG="${DREVOPS_TEST_UNIT_CONFIG:-${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist}"
 
 # Flag to allow Kernel tests to fail.
 DREVOPS_TEST_KERNEL_ALLOW_FAILURE="${DREVOPS_TEST_KERNEL_ALLOW_FAILURE:-0}"
 
-# Kernel test group. Optional. Default runs all tests.
-DREVOPS_TEST_KERNEL_GROUP="${DREVOPS_TEST_KERNEL_GROUP:-}"
+# Kernel test group. Optional. Defaults to running Kernel tests tagged with `site:kernel`.
+DREVOPS_TEST_KERNEL_GROUP="${DREVOPS_TEST_KERNEL_GROUP:-site:kernel}"
+
+# Kernel test configuration file. Optional. Defaults to core's configuration.
+DREVOPS_TEST_KERNEL_CONFIG="${DREVOPS_TEST_KERNEL_CONFIG:-${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist}"
 
 # Flag to allow Functional tests to fail.
 DREVOPS_TEST_FUNCTIONAL_ALLOW_FAILURE="${DREVOPS_TEST_FUNCTIONAL_ALLOW_FAILURE:-0}"
 
-# Functional test group. Optional. Default runs all tests.
-DREVOPS_TEST_FUNCTIONAL_GROUP="${DREVOPS_TEST_FUNCTIONAL_GROUP:-}"
+# Kernel test group. Optional. Defaults to running Functional tests tagged with `site:functional`.
+DREVOPS_TEST_FUNCTIONAL_GROUP="${DREVOPS_TEST_FUNCTIONAL_GROUP:-site:functional}"
+
+# Functional test configuration file. Optional. Defaults to core's configuration.
+DREVOPS_TEST_FUNCTIONAL_CONFIG="${DREVOPS_TEST_FUNCTIONAL_CONFIG:-${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist}"
 
 # Flag to allow BDD tests to fail.
 DREVOPS_TEST_BDD_ALLOW_FAILURE="${DREVOPS_TEST_BDD_ALLOW_FAILURE:-0}"
@@ -69,12 +85,6 @@ DREVOPS_TEST_REPORTS_DIR="${DREVOPS_TEST_REPORTS_DIR:-}"
 # Directory to store test artifact files.
 DREVOPS_TEST_ARTIFACT_DIR="${DREVOPS_TEST_ARTIFACT_DIR:-}"
 
-# Path to the root of the project inside the container.
-DREVOPS_APP=/app
-
-# Name of the webroot directory with Drupal installation.
-DREVOPS_WEBROOT="${DREVOPS_WEBROOT:-web}"
-
 # ------------------------------------------------------------------------------
 
 # Get test type or fallback to defaults.
@@ -89,23 +99,37 @@ DREVOPS_TEST_TYPE="${DREVOPS_TEST_TYPE:-unit-kernel-functional-bdd}"
 if [ -z "${DREVOPS_TEST_TYPE##*unit*}" ]; then
   echo "[INFO] Running unit tests."
 
-  phpunit_opts=(-c "${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist")
-  [ -n "${DREVOPS_TEST_UNIT_GROUP}" ] && phpunit_opts+=(--group="${DREVOPS_TEST_UNIT_GROUP}")
+  # Generic tests that do not require Drupal bootstrap.
+  phpunit_opts=()
   [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && phpunit_opts+=(--log-junit "${DREVOPS_TEST_REPORTS_DIR}/phpunit/unit.xml")
-
-  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom/" --exclude-group=skipped --filter '/.*Unit.*/' "$@" \
-  && echo "  [OK] Unit tests passed." \
+  vendor/bin/phpunit "${phpunit_opts[@]}" "tests/phpunit" --exclude-group=skipped  --group "${DREVOPS_TEST_UNIT_GROUP}" "$@" \
+  && echo "  [OK] Unit tests for scripts passed." \
   || [ "${DREVOPS_TEST_UNIT_ALLOW_FAILURE}" -eq 1 ]
+
+  # Custom modules tests that require Drupal bootstrap.
+  phpunit_opts=(-c "${DREVOPS_TEST_UNIT_CONFIG}")
+  [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && phpunit_opts+=(--log-junit "${DREVOPS_TEST_REPORTS_DIR}/phpunit/unit_modules.xml")
+  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom" --exclude-group=skipped --group "${DREVOPS_TEST_UNIT_GROUP}" "$@" \
+  && echo "  [OK] Unit tests for modules passed." \
+  || [ "${DREVOPS_TEST_UNIT_ALLOW_FAILURE}" -eq 1 ]
+
+  # Custom theme tests that require Drupal bootstrap.
+  if [ -n "${DREVOPS_DRUPAL_THEME}" ]; then
+    phpunit_opts=(-c "${DREVOPS_TEST_UNIT_CONFIG}")
+    [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && phpunit_opts+=(--log-junit "${DREVOPS_TEST_REPORTS_DIR}/phpunit/unit_themes.xml")
+    vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/themes/custom" --exclude-group=skipped --group "${DREVOPS_TEST_UNIT_GROUP}" "$@" \
+    && echo "  [OK] Unit tests for themes passed." \
+    || [ "${DREVOPS_TEST_UNIT_ALLOW_FAILURE}" -eq 1 ]
+  fi
 fi
 
 if [ -z "${DREVOPS_TEST_TYPE##*kernel*}" ]; then
   echo "[INFO] Running Kernel tests"
 
-  phpunit_opts=(-c "${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist")
-  [ -n "${DREVOPS_TEST_KERNEL_GROUP}" ] && phpunit_opts+=(--group="${DREVOPS_TEST_KERNEL_GROUP}")
+  phpunit_opts=(-c "${DREVOPS_TEST_KERNEL_CONFIG}")
   [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && phpunit_opts+=(--log-junit "${DREVOPS_TEST_REPORTS_DIR}/phpunit/kernel.xml")
 
-  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom/" --exclude-group=skipped --filter '/.*Kernel.*/' "$@" \
+  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom/" --exclude-group=skipped --group "${DREVOPS_TEST_KERNEL_GROUP}" "$@" \
   && echo "  [OK] Kernel tests passed." \
   || [ "${DREVOPS_TEST_KERNEL_ALLOW_FAILURE:-0}" -eq 1 ]
 fi
@@ -113,11 +137,10 @@ fi
 if [ -z "${DREVOPS_TEST_TYPE##*functional*}" ]; then
   echo "[INFO] Running Functional tests"
 
-  phpunit_opts=(-c "${DREVOPS_APP}/${DREVOPS_WEBROOT}/core/phpunit.xml.dist")
-  [ -n "${DREVOPS_TEST_FUNCTIONAL_GROUP}" ] && phpunit_opts+=(--group="${DREVOPS_TEST_FUNCTIONAL_GROUP}")
+  phpunit_opts=(-c "${DREVOPS_TEST_FUNCTIONAL_CONFIG}")
   [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && phpunit_opts+=(--log-junit "${DREVOPS_TEST_REPORTS_DIR}/phpunit/functional.xml")
 
-  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom/" --exclude-group=skipped --filter '/.*Functional.*/' "$@" \
+  vendor/bin/phpunit "${phpunit_opts[@]}" "${DREVOPS_WEBROOT}/modules/custom/" --exclude-group=skipped --group "${DREVOPS_TEST_FUNCTIONAL_GROUP}" "$@" \
   && echo "  [OK] Functional tests passed." \
   || [ "${DREVOPS_TEST_FUNCTIONAL_ALLOW_FAILURE:-0}" -eq 1 ]
 fi
@@ -127,8 +150,9 @@ if [ -z "${DREVOPS_TEST_TYPE##*bdd*}" ]; then
 
   # Use parallel Behat profile if using more than a single node to run tests.
   if [ -n "${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}" ] ; then
-    DREVOPS_TEST_BEHAT_PROFILE="p${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}"
-    echo "     > Using Behat profile \"${DREVOPS_TEST_BEHAT_PROFILE}\"."
+    # Allow to have flexible profile name based on index.
+    DREVOPS_TEST_BEHAT_PROFILE="${DREVOPS_TEST_BEHAT_PROFILE:-p}${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}"
+    echo "==> Running using profile \"${DREVOPS_TEST_BEHAT_PROFILE}\"."
   fi
 
   behat_opts=(
@@ -139,9 +163,9 @@ if [ -z "${DREVOPS_TEST_TYPE##*bdd*}" ]; then
     --out std
   )
 
+  [ -n "${DREVOPS_TEST_ARTIFACT_DIR}" ] && export BEHAT_SCREENSHOT_DIR="${DREVOPS_TEST_ARTIFACT_DIR}/screenshots"
   [ -n "${DREVOPS_TEST_BEHAT_TAGS}" ] && behat_opts+=(--tags="${DREVOPS_TEST_BEHAT_TAGS}")
   [ -n "${DREVOPS_TEST_REPORTS_DIR}" ] && behat_opts+=(--format "junit" --out "${DREVOPS_TEST_REPORTS_DIR}/behat")
-  [ -n "${DREVOPS_TEST_ARTIFACT_DIR}" ] && export BEHAT_SCREENSHOT_DIR="${DREVOPS_TEST_ARTIFACT_DIR}/screenshots"
 
   # Run tests once and re-run on fail, but only in CI.
   vendor/bin/behat "${behat_opts[@]}" "$@" \

--- a/scripts/drevops/test.sh
+++ b/scripts/drevops/test.sh
@@ -150,9 +150,8 @@ if [ -z "${DREVOPS_TEST_TYPE##*bdd*}" ]; then
 
   # Use parallel Behat profile if using more than a single node to run tests.
   if [ -n "${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}" ] ; then
-    # Allow to have flexible profile name based on index.
-    DREVOPS_TEST_BEHAT_PROFILE="${DREVOPS_TEST_BEHAT_PROFILE:-p}${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}"
-    echo "==> Running using profile \"${DREVOPS_TEST_BEHAT_PROFILE}\"."
+    DREVOPS_TEST_BEHAT_PROFILE="p${DREVOPS_TEST_BEHAT_PARALLEL_INDEX}"
+    echo "     > Using Behat profile \"${DREVOPS_TEST_BEHAT_PROFILE}\"."
   fi
 
   behat_opts=(

--- a/scripts/drevops/tests/.aspell.en.pws
+++ b/scripts/drevops/tests/.aspell.en.pws
@@ -18,7 +18,10 @@ DevOps
 DockerHub
 DrevOps
 Drupal
+DrupalExtension
+Entrypoint
 FE
+FeatureContext
 GPL
 GraphQL
 Gruntfile
@@ -45,8 +48,8 @@ SCSS
 SHA
 SLAs
 SemVer
-Ssl
 SsL
+Ssl
 TBD
 UAT
 UI
@@ -60,9 +63,11 @@ Xdebug
 YOURORG
 YOURSITE
 amazeeio
+bdd
 breakpoint
 changelog
 codebase
+contrib
 customisations
 dev
 drush

--- a/scripts/drevops/tests/bats/_helper.bash
+++ b/scripts/drevops/tests/bats/_helper.bash
@@ -124,8 +124,9 @@ assert_files_present() {
   local suffix="${2:-star_wars}"
   local suffix_abbreviated="${3:-sw}"
   local suffix_abbreviated_camel_cased="${4:-Sw}"
+  local suffix_camel_cased="${5:-StarWars}"
 
-  assert_files_present_common "${dir}" "${suffix}" "${suffix_abbreviated}" "${suffix_abbreviated_camel_cased}"
+  assert_files_present_common "${dir}" "${suffix}" "${suffix_abbreviated}" "${suffix_abbreviated_camel_cased}" "${suffix_camel_cased}"
 
   assert_files_local_present "${dir}"
 
@@ -167,7 +168,8 @@ assert_files_present_common() {
   local suffix="${2:-star_wars}"
   local suffix_abbreviated="${3:-sw}"
   local suffix_abbreviated_camel_cased="${4:-Sw}"
-  local webroot="${5:-web}"
+  local suffix_camel_cased="${5:-StarWars}"
+  local webroot="${6:-web}"
 
   local suffix_abbreviated_uppercase="$(string_to_upper "$suffix_abbreviated")"
   local suffix_hyphenated="${suffix/_/-}"
@@ -185,7 +187,7 @@ assert_files_present_common() {
   assert_file_contains "README.md" "badge/DrevOps-${DREVOPS_DRUPAL_VERSION}.x-blue.svg"
   assert_file_contains "README.md" "https://github.com/drevops/drevops/tree/${DREVOPS_DRUPAL_VERSION}.x"
 
-  assert_files_present_drupal "${dir}" "${suffix}" "${suffix_abbreviated}" "${suffix_abbreviated_camel_cased}" "${webroot}"
+  assert_files_present_drupal "${dir}" "${suffix}" "${suffix_abbreviated}" "${suffix_abbreviated_camel_cased}" "${suffix_camel_cased}" "${webroot}"
 
   # Assert that PR template was processed
   assert_file_contains ".github/PULL_REQUEST_TEMPLATE.md" "https://${suffix_hyphenated}.atlassian.net/browse/${suffix_abbreviated_uppercase}-"
@@ -374,7 +376,8 @@ assert_files_present_drupal() {
   local suffix="${2:-star_wars}"
   local suffix_abbreviated="${3:-sw}"
   local suffix_abbreviated_camel_cased="${4:-Sw}"
-  local webroot="${5:-web}"
+  local suffix_camel_cased="${5:-StarWars}"
+  local webroot="${6:-web}"
 
   pushd "${dir}" >/dev/null || exit 1
 
@@ -390,12 +393,12 @@ assert_files_present_drupal() {
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/${suffix_abbreviated}_core.info.yml"
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/${suffix_abbreviated}_core.module"
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/${suffix_abbreviated}_core.deploy.php"
-  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Unit/${suffix_abbreviated_camel_cased}CoreExampleUnitTest.php"
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Unit/${suffix_abbreviated_camel_cased}CoreUnitTestBase.php"
-  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Kernel/${suffix_abbreviated_camel_cased}CoreExampleKernelTest.php"
+  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Unit/ExampleTest.php"
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Kernel/${suffix_abbreviated_camel_cased}CoreKernelTestBase.php"
-  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Functional/${suffix_abbreviated_camel_cased}CoreExampleFunctionalTest.php"
+  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Kernel/ExampleTest.php"
   assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Functional/${suffix_abbreviated_camel_cased}CoreFunctionalTestBase.php"
+  assert_file_exists "${webroot}/modules/custom/${suffix_abbreviated}_core/tests/src/Functional/ExampleTest.php"
 
   # Site theme created.
   assert_dir_exists "${webroot}/themes/custom/${suffix}"
@@ -409,6 +412,13 @@ assert_files_present_drupal() {
   assert_file_exists "${webroot}/themes/custom/${suffix}/${suffix}.theme"
   assert_file_exists "${webroot}/themes/custom/${suffix}/Gruntfile.js"
   assert_file_exists "${webroot}/themes/custom/${suffix}/package.json"
+
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Unit/${suffix_camel_cased}UnitTestBase.php"
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Unit/ExampleTest.php"
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Kernel/${suffix_camel_cased}KernelTestBase.php"
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Kernel/ExampleTest.php"
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Functional/${suffix_camel_cased}FunctionalTestBase.php"
+  assert_file_exists "${webroot}/themes/custom/${suffix}/tests/src/Functional/ExampleTest.php"
 
   # Comparing binary files.
   assert_binary_files_equal "${LOCAL_REPO_DIR}/web/themes/custom/your_site_theme/screenshot.png" "${webroot}/themes/custom/${suffix}/screenshot.png"

--- a/scripts/drevops/tests/bats/_helper_workflow.bash
+++ b/scripts/drevops/tests/bats/_helper_workflow.bash
@@ -370,6 +370,7 @@ assert_ahoy_test_unit() {
   assert_output_contains "Unit tests for modules passed"
   assert_output_contains "OK (7 tests, 7 assertions)"
   assert_output_contains "Unit tests for themes passed"
+  sync_to_host
   assert_dir_not_empty "test_reports"
   assert_file_exists "test_reports/phpunit/unit.xml"
   assert_file_exists "test_reports/phpunit/unit_modules.xml"
@@ -421,6 +422,7 @@ assert_ahoy_test_kernel() {
   assert_success
   assert_output_contains "OK (5 tests, 5 assertions)"
   assert_output_contains "Kernel tests passed"
+  sync_to_host
   assert_dir_not_empty "test_reports"
   assert_file_exists "test_reports/phpunit/kernel.xml"
 
@@ -463,6 +465,7 @@ assert_ahoy_test_functional() {
   assert_success
   assert_output_contains "OK (2 tests, 4 assertions)"
   assert_output_contains "Functional tests passed"
+  sync_to_host
   assert_dir_not_empty "test_reports"
   assert_file_exists "test_reports/phpunit/functional.xml"
 

--- a/scripts/drevops/tests/bats/install_existing.bats
+++ b/scripts/drevops/tests/bats/install_existing.bats
@@ -320,7 +320,7 @@ load _helper.bash
 
   install_dependencies_stub "" "rootdoc"
 
-  assert_files_present_common "" "" "" "" "rootdoc"
+  assert_files_present_common "" "" "" "" "" "rootdoc"
 }
 
 @test "Install into existing: previously installed project; custom theme; discovery; quiet" {

--- a/scripts/drevops/tests/bats/install_initial.bats
+++ b/scripts/drevops/tests/bats/install_initial.bats
@@ -20,7 +20,7 @@ load _helper.bash
 @test "Install into empty directory: DREVOPS_INSTALL_DST_DIR from an argument" {
   run_install_quiet "${DST_PROJECT_DIR}"
 
-  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds"
+  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds" "Dst"
   assert_git_repo "${DST_PROJECT_DIR}"
 }
 
@@ -28,7 +28,7 @@ load _helper.bash
   export DREVOPS_INSTALL_DST_DIR="${DST_PROJECT_DIR}"
   run_install_quiet
 
-  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds"
+  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds" "Dst"
   assert_git_repo "${DST_PROJECT_DIR}"
 }
 
@@ -37,7 +37,7 @@ load _helper.bash
 
   run_install_quiet
 
-  assert_files_present "${CURRENT_PROJECT_DIR}" "the_matrix" "tm" "Tm"
+  assert_files_present "${CURRENT_PROJECT_DIR}" "the_matrix" "tm" "Tm" "TheMatrix"
   assert_git_repo
 }
 
@@ -46,7 +46,7 @@ load _helper.bash
 
   run_install_quiet
 
-  assert_files_present "${CURRENT_PROJECT_DIR}" "the_matrix" "tm" "Tm"
+  assert_files_present "${CURRENT_PROJECT_DIR}" "the_matrix" "tm" "Tm" "TheMatrix"
   assert_git_repo
 }
 
@@ -236,7 +236,7 @@ load _helper.bash
 @test "Install into empty directory; DrevOps scripts are not modified" {
   run_install_quiet "${DST_PROJECT_DIR}"
 
-  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds"
+  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds" "Dst"
   assert_git_repo "${DST_PROJECT_DIR}"
 
   assert_dirs_equal "${LOCAL_REPO_DIR}/scripts/composer" "${DST_PROJECT_DIR}/scripts/composer"
@@ -246,7 +246,7 @@ load _helper.bash
 @test "Install into empty directory; Images are not modified" {
   run_install_quiet "${DST_PROJECT_DIR}"
 
-  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds"
+  assert_files_present "${DST_PROJECT_DIR}" "dst" "ds" "Ds" "Dst"
   assert_git_repo "${DST_PROJECT_DIR}"
 
   assert_binary_files_equal "${LOCAL_REPO_DIR}/tests/behat/fixtures/image.jpg" "${DST_PROJECT_DIR}/tests/behat/fixtures/image.jpg"

--- a/web/modules/custom/ys_core/tests/src/Functional/ExampleTest.php
+++ b/web/modules/custom/ys_core/tests/src/Functional/ExampleTest.php
@@ -3,13 +3,16 @@
 namespace Drupal\Tests\ys_core\Functional;
 
 /**
- * Class YsCoreExampleFunctionalTest.
+ * Class ExampleTest.
  *
- * Example test case class.
+ * Example functional test case class.
  *
  * @group YsCore
+ * @group site:functional
+ *
+ * @package Drupal\ys_core\Tests
  */
-class YsCoreExampleFunctionalTest extends YsCoreFunctionalTestBase {
+class ExampleTest extends YsCoreFunctionalTestBase {
 
   /**
    * {@inheritdoc}
@@ -37,7 +40,7 @@ class YsCoreExampleFunctionalTest extends YsCoreFunctionalTestBase {
   /**
    * Temporary test stub.
    *
-   * @group subtraction
+   * @group functional:subtraction
    */
   public function testSubtraction() {
     $this->assertEquals(1, 2 - 1);

--- a/web/modules/custom/ys_core/tests/src/Functional/YsCoreFunctionalTestBase.php
+++ b/web/modules/custom/ys_core/tests/src/Functional/YsCoreFunctionalTestBase.php
@@ -7,6 +7,10 @@ use Drupal\Tests\ys_core\Traits\YsCoreTestHelperTrait;
 
 /**
  * Class YsCoreKernelTestBase.
+ *
+ * Base class for functional tests.
+ *
+ * @package Drupal\ys_core\Tests
  */
 abstract class YsCoreFunctionalTestBase extends BrowserTestBase {
 

--- a/web/modules/custom/ys_core/tests/src/Kernel/ExampleTest.php
+++ b/web/modules/custom/ys_core/tests/src/Kernel/ExampleTest.php
@@ -1,15 +1,18 @@
 <?php
 
-namespace Drupal\Tests\ys_core\Unit;
+namespace Drupal\Tests\ys_core\Kernel;
 
 /**
- * Class YsCoreExampleUnitTest.
+ * Class ExampleTest.
  *
- * Example test case class.
+ * Example kernel test case class.
  *
  * @group YsCore
+ * @group site:kernel
+ *
+ * @package Drupal\ys_core\Tests
  */
-class YsCoreExampleUnitTest extends YsCoreUnitTestBase {
+class ExampleTest extends YsCoreKernelTestBase {
 
   /**
    * Tests addition.
@@ -43,7 +46,7 @@ class YsCoreExampleUnitTest extends YsCoreUnitTestBase {
    * Tests subtraction.
    *
    * @dataProvider dataProviderSubtract
-   * @group subtraction
+   * @group kernel:subtraction
    */
   public function testSubtract($a, $b, $expected, $expectExceptionMessage = NULL) {
     if ($expectExceptionMessage) {

--- a/web/modules/custom/ys_core/tests/src/Kernel/YsCoreKernelTestBase.php
+++ b/web/modules/custom/ys_core/tests/src/Kernel/YsCoreKernelTestBase.php
@@ -9,6 +9,8 @@ use Drupal\Tests\ys_core\Traits\YsCoreTestHelperTrait;
  * Class YsCoreKernelTestBase.
  *
  * Base class for kernel tests.
+ *
+ * @package Drupal\ys_core\Tests
  */
 abstract class YsCoreKernelTestBase extends KernelTestBase {
 

--- a/web/modules/custom/ys_core/tests/src/Unit/ExampleTest.php
+++ b/web/modules/custom/ys_core/tests/src/Unit/ExampleTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\ys_core\Unit;
+
+/**
+ * Class ExampleTest.
+ *
+ * Example unit test case class.
+ *
+ * @group YsCore
+ * @group site:unit
+ *
+ * @package Drupal\ys_core\Tests
+ */
+class ExampleTest extends YsCoreUnitTestBase {
+
+  /**
+   * Tests addition.
+   *
+   * @dataProvider dataProviderAdd
+   * @group addition
+   */
+  public function testAdd($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a + $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testAdd().
+   */
+  public function dataProviderAdd() {
+    return [
+      [0, 0, 0],
+      [1, 1, 2],
+    ];
+  }
+
+  /**
+   * Tests subtraction.
+   *
+   * @dataProvider dataProviderSubtract
+   * @group unit:subtraction
+   */
+  public function testSubtract($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a - $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testSubtract().
+   */
+  public function dataProviderSubtract() {
+    return [
+      [0, 0, 0],
+      [1, 1, 0],
+      [2, 1, 1],
+    ];
+  }
+
+  /**
+   * Tests multiplication.
+   *
+   * @dataProvider dataProviderMultiplication
+   * @group multiplication
+   * @group skipped
+   */
+  public function testMultiplication($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a * $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testMultiplication().
+   */
+  public function dataProviderMultiplication() {
+    return [
+      [0, 0, 0],
+      [1, 1, 1],
+      [2, 1, 2],
+    ];
+  }
+
+}

--- a/web/modules/custom/ys_core/tests/src/Unit/YsCoreUnitTestBase.php
+++ b/web/modules/custom/ys_core/tests/src/Unit/YsCoreUnitTestBase.php
@@ -9,6 +9,8 @@ use Drupal\Tests\ys_core\Traits\YsCoreTestHelperTrait;
  * Class YsCoreUnitTestBase.
  *
  * Base class for all unit test cases.
+ *
+ * @package Drupal\ys_core\Tests
  */
 abstract class YsCoreUnitTestBase extends UnitTestCase {
 

--- a/web/themes/custom/your_site_theme/tests/src/Functional/ExampleTest.php
+++ b/web/themes/custom/your_site_theme/tests/src/Functional/ExampleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Functional;
+
+/**
+ * Class ExampleTest.
+ *
+ * Example functional test case class.
+ *
+ * @group YourSiteTheme
+ * @group site:functional
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+class ExampleTest extends YourSiteThemeFunctionalTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    // DrevOps does not support Functional tests due to permission issues.
+    // Override setup until @see https://github.com/drevops/drevops/issues/820
+    // resolved.
+    // This test is left here to make sure that all DrevOps tooling works as
+    // expected.
+  }
+
+  /**
+   * Temporary test stub.
+   *
+   * @group addition
+   */
+  public function testAddition() {
+    $this->assertEquals(2, 1 + 1);
+    // DrevOps does not support Functional tests due to permission issues.
+    // @see https://github.com/drevops/drevops/issues/820
+    $this->addToAssertionCount(1);
+  }
+
+  /**
+   * Temporary test stub.
+   *
+   * @group functional:subtraction
+   */
+  public function testSubtraction() {
+    $this->assertEquals(1, 2 - 1);
+    // DrevOps does not support Functional tests due to permission issues.
+    // @see https://github.com/drevops/drevops/issues/820
+    $this->addToAssertionCount(1);
+  }
+
+}

--- a/web/themes/custom/your_site_theme/tests/src/Functional/YourSiteThemeFunctionalTestBase.php
+++ b/web/themes/custom/your_site_theme/tests/src/Functional/YourSiteThemeFunctionalTestBase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\your_site_theme\Traits\YourSiteThemeTestHelperTrait;
+
+/**
+ * Class YourSiteThemeFunctionalTestBase.
+ *
+ * Base class for functional tests.
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+abstract class YourSiteThemeFunctionalTestBase extends BrowserTestBase {
+
+  use YourSiteThemeTestHelperTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+}

--- a/web/themes/custom/your_site_theme/tests/src/Kernel/ExampleTest.php
+++ b/web/themes/custom/your_site_theme/tests/src/Kernel/ExampleTest.php
@@ -1,15 +1,18 @@
 <?php
 
-namespace Drupal\Tests\ys_core\Kernel;
+namespace Drupal\Tests\your_site_theme\Kernel;
 
 /**
- * Class YsCoreExampleKernelTest.
+ * Class ExampleTest.
  *
- * Example test case class.
+ * Example kernel test case class.
  *
- * @group YsCore
+ * @group YourSiteTheme
+ * @group site:kernel
+ *
+ * @package Drupal\your_site_theme\Tests
  */
-class YsCoreExampleKernelTest extends YsCoreKernelTestBase {
+class ExampleTest extends YourSiteThemeKernelTestBase {
 
   /**
    * Tests addition.
@@ -36,6 +39,7 @@ class YsCoreExampleKernelTest extends YsCoreKernelTestBase {
     return [
       [0, 0, 0],
       [1, 1, 2],
+      [3, 1, 4],
     ];
   }
 
@@ -43,7 +47,7 @@ class YsCoreExampleKernelTest extends YsCoreKernelTestBase {
    * Tests subtraction.
    *
    * @dataProvider dataProviderSubtract
-   * @group subtraction
+   * @group kernel:subtraction
    */
   public function testSubtract($a, $b, $expected, $expectExceptionMessage = NULL) {
     if ($expectExceptionMessage) {
@@ -65,6 +69,7 @@ class YsCoreExampleKernelTest extends YsCoreKernelTestBase {
       [0, 0, 0],
       [1, 1, 0],
       [2, 1, 1],
+      [3, 1, 2],
     ];
   }
 

--- a/web/themes/custom/your_site_theme/tests/src/Kernel/YourSiteThemeKernelTestBase.php
+++ b/web/themes/custom/your_site_theme/tests/src/Kernel/YourSiteThemeKernelTestBase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\your_site_theme\Traits\YourSiteThemeTestHelperTrait;
+
+/**
+ * Class YourSiteThemeKernelTestBase.
+ *
+ * Base class for kernel tests.
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+abstract class YourSiteThemeKernelTestBase extends KernelTestBase {
+
+  use YourSiteThemeTestHelperTrait;
+
+}

--- a/web/themes/custom/your_site_theme/tests/src/Traits/YourSiteThemeTestHelperTrait.php
+++ b/web/themes/custom/your_site_theme/tests/src/Traits/YourSiteThemeTestHelperTrait.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Traits;
+
+/**
+ * Trait YourSiteThemeTestHelperTrait.
+ *
+ * Helper trait for tests.
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+trait YourSiteThemeTestHelperTrait {
+
+  /**
+   * Call protected methods on the class.
+   *
+   * @param object|string $object
+   *   Object or class name to use for a method call.
+   * @param string $method
+   *   Method name. Method can be static.
+   * @param array $args
+   *   Array of arguments to pass to the method. To pass arguments by reference,
+   *   pass them by reference as an element of this array.
+   *
+   * @return mixed
+   *   Method result.
+   */
+  protected static function callProtectedMethod($object, $method, array $args = []) {
+    $class = new \ReflectionClass(is_object($object) ? get_class($object) : $object);
+    $method = $class->getMethod($method);
+    $method->setAccessible(TRUE);
+    $object = $method->isStatic() ? NULL : $object;
+
+    return $method->invokeArgs($object, $args);
+  }
+
+  /**
+   * Set protected property value.
+   *
+   * @param object $object
+   *   Object to set the value on.
+   * @param string $property
+   *   Property name to set the value. Property should exists in the object.
+   * @param mixed $value
+   *   Value to set to the property.
+   */
+  protected static function setProtectedValue($object, $property, $value) {
+    $class = new \ReflectionClass(get_class($object));
+    $property = $class->getProperty($property);
+    $property->setAccessible(TRUE);
+
+    $property->setValue($object, $value);
+  }
+
+  /**
+   * Get protected value from the object.
+   *
+   * @param object $object
+   *   Object to set the value on.
+   * @param string $property
+   *   Property name to get the value. Property should exists in the object.
+   *
+   * @return mixed
+   *   Protected property value.
+   */
+  protected static function getProtectedValue($object, $property) {
+    $class = new \ReflectionClass(get_class($object));
+    $property = $class->getProperty($property);
+    $property->setAccessible(TRUE);
+
+    return $property->getValue($class);
+  }
+
+  /**
+   * Helper to prepare class mock.
+   *
+   * @param string $class
+   *   Class name to generate the mock.
+   * @param array $methodsMap
+   *   Optional array of methods and values, keyed by method name.
+   * @param array $args
+   *   Optional array of constructor arguments. If omitted, a constructor will
+   *   not be called.
+   *
+   * @return object
+   *   Mocked class.
+   */
+  protected function prepareMock($class, array $methodsMap = [], array $args = []) {
+    $methods = array_keys($methodsMap);
+
+    $reflectionClass = new \ReflectionClass($class);
+
+    if ($reflectionClass->isAbstract()) {
+      $mock = $this->getMockForAbstractClass(
+        $class, $args, '', !empty($args), TRUE, TRUE, $methods
+      );
+    }
+    else {
+      $mock = $this->getMockBuilder($class);
+      if (!empty($args)) {
+        $mock = $mock->enableOriginalConstructor()
+          ->setConstructorArgs($args);
+      }
+      else {
+        $mock = $mock->disableOriginalConstructor();
+      }
+      $mock = $mock->setMethods($methods)
+        ->getMock();
+    }
+
+    foreach ($methodsMap as $method => $value) {
+      // Handle callback values differently.
+      if (is_object($value) && strpos(get_class($value), 'Callback') !== FALSE) {
+        $mock->expects($this->any())
+          ->method($method)
+          ->will($value);
+      }
+      else {
+        $mock->expects($this->any())
+          ->method($method)
+          ->willReturn($value);
+      }
+    }
+
+    return $mock;
+  }
+
+  /**
+   * Check if testing framework was ran with --debug option.
+   */
+  protected function isDebug() {
+    return in_array('--debug', $_SERVER['argv'], TRUE);
+  }
+
+}

--- a/web/themes/custom/your_site_theme/tests/src/Unit/ExampleTest.php
+++ b/web/themes/custom/your_site_theme/tests/src/Unit/ExampleTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Unit;
+
+/**
+ * Class ExampleTest.
+ *
+ * Example unit test case class.
+ *
+ * @group YourSiteTheme
+ * @group site:unit
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+class ExampleTest extends YourSiteThemeUnitTestBase {
+
+  /**
+   * Tests addition.
+   *
+   * @dataProvider dataProviderAdd
+   * @group addition
+   */
+  public function testAdd($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a + $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testAdd().
+   */
+  public function dataProviderAdd() {
+    return [
+      [0, 0, 0],
+      [1, 1, 2],
+      [2, 1, 3],
+    ];
+  }
+
+  /**
+   * Tests subtraction.
+   *
+   * @dataProvider dataProviderSubtract
+   * @group unit:subtraction
+   */
+  public function testSubtract($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a - $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testSubtract().
+   */
+  public function dataProviderSubtract() {
+    return [
+      [0, 0, 0],
+      [1, 1, 0],
+      [2, 1, 1],
+      [3, 1, 2],
+    ];
+  }
+
+  /**
+   * Tests multiplication.
+   *
+   * @dataProvider dataProviderMultiplication
+   * @group multiplication
+   * @group skipped
+   */
+  public function testMultiplication($a, $b, $expected, $expectExceptionMessage = NULL) {
+    if ($expectExceptionMessage) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($expectExceptionMessage);
+    }
+
+    // Replace below with a call to your class method.
+    $actual = $a * $b;
+
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider for testMultiplication().
+   */
+  public function dataProviderMultiplication() {
+    return [
+      [0, 0, 0],
+      [1, 1, 1],
+      [2, 1, 2],
+    ];
+  }
+
+}

--- a/web/themes/custom/your_site_theme/tests/src/Unit/YourSiteThemeUnitTestBase.php
+++ b/web/themes/custom/your_site_theme/tests/src/Unit/YourSiteThemeUnitTestBase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\Tests\your_site_theme\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\Tests\your_site_theme\Traits\YourSiteThemeTestHelperTrait;
+
+/**
+ * Class YourSiteThemeUnitTestBase.
+ *
+ * Base class for all unit test cases.
+ *
+ * @package Drupal\your_site_theme\Tests
+ */
+abstract class YourSiteThemeUnitTestBase extends UnitTestCase {
+
+  use YourSiteThemeTestHelperTrait;
+
+}


### PR DESCRIPTION
closes #741 

- Added support for tests in scripts
- Added support for tests in themes
- Tests now needs to be correctly tagged with `site:<suite>` (`site:unit', `site:kernel`, `site:functional`) instead of having a `<Suit>Test.php` suffix
- Added documentation about running tests
