### PR TITLE
chore: Added multi-version docs publishing.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,7 +561,8 @@ jobs:
             sed -i -e "/###/d" docker-compose.yml
             ahoy build
             ahoy test
-            ahoy publish
+            if [ -n "${CIRCLE_TAG:-}" ]; then export version="${CIRCLE_TAG:-}"; elif [ -n "${CIRCLE_BRANCH}" ] && [ "${CIRCLE_BRANCH:-}" != "main" ]; then export version="${CIRCLE_BRANCH/\//-}"; fi
+            ahoy publish "${version:-}"
             mkdir -p /tmp/docs
             docker compose cp mkdocs:"/app/site/." "/tmp/docs"
       - run:
@@ -746,7 +747,8 @@ workflows:
             - drevops_dev_test_workflow
           filters:
             branches:
-              only: /^feature\/docs-update$/
+              # 'main' or any branch with 'docs' in the name.
+              only: /^main$|.*docs.*/
             tags:
               only: /^[0-9]+(\.[0-9]+)+(-rc[0-9]+)?$/
 

--- a/scripts/drevops/docs/.ahoy.yml
+++ b/scripts/drevops/docs/.ahoy.yml
@@ -17,8 +17,7 @@ commands:
 
   publish:
     usage: Deploy site
-    # Make sure that your SSH config and keys have correct permissions or this will fail.
-    cmd: docker compose exec mkdocs mkdocs build
+    cmd: docker compose exec mkdocs sh -c "/app/.utils/release.sh $@"
 
   update:
     usage: Update docs
@@ -51,6 +50,10 @@ commands:
   stop:
     usage: Stop running Docker containers.
     cmd: docker compose stop "$@"
+
+  cli:
+    usage: Start a shell or run a command inside the CLI service container.
+    cmd: if \[ "${#}" -ne 0 \]; then docker compose exec -T mkdocs sh -c "$*"; else docker compose exec mkdocs sh; fi
 
   line:
     cmd: printf "$(tput -Txterm setaf 2)${1}$(tput -Txterm sgr0)${2}\n"

--- a/scripts/drevops/docs/.utils/Dockerfile
+++ b/scripts/drevops/docs/.utils/Dockerfile
@@ -5,7 +5,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN pip install mdx_include mkdocs-same-dir mkdocs-replace-markdown
+RUN pip install mdx_include mkdocs-same-dir mkdocs-replace-markdown mike
 
 WORKDIR /app
 

--- a/scripts/drevops/docs/.utils/release.sh
+++ b/scripts/drevops/docs/.utils/release.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env sh
+##
+# Update docs.
+#
+# @usage
+# cd scripts/drevops/docs && ./release.sh
+
+# cd scripts/drevops/docs && ./release.sh version
+#
+# cd scripts/drevops/docs && ./release.sh version ./site
+#
+# shellcheck disable=SC2129
+
+set -e
+[ -n "${DREVOPS_DEBUG}" ] && set -x
+
+# Name of the version to considered to be the development.
+VERSION_DEV="${VERSION_DEV:-dev}"
+
+# Name of the version to considered to be the latest.
+VERSION_LATEST="${VERSION_LATEST:-latest}"
+
+# Name of the version to be released. Defaults to the development version.
+VERSION="${1:-${VERSION_DEV}}"
+
+# Directory with the source files.
+SRC_DIR="${SRC_DIR:-/app}"
+
+# The output directory to copy the built files to.
+OUTPUT_DIR="${2:-./site}"
+
+# Source repository URL.
+SRC_REPO_URL="${SRC_REPO:-https://github.com/drevops/drevops_docs.git}"
+
+# Source repository branch.
+SRC_REPO_BRANCH="${SRC_REPO_BRANCH:-master}"
+
+# Temporary directory.
+TMP_DIR="${TMP_DIR:-/tmp/release}"
+
+# Source directory.
+REPO_DIR="${REPO_DIR:-${TMP_DIR}/src}"
+
+# Directory to use for a "clean" codebase.
+REPO_DIR_CLEAN="${REPO_DIR2:-${TMP_DIR}/src_clean}"
+
+#-------------------------------------------------------------------------------
+
+echo "Started release."
+
+# Configure global git settings, if they do not exist. This is not used to push changes.
+[ "$(git config --global user.name)" = "" ] && echo "Configuring global git user name." && git config --global user.name "Deployment robot"
+[ "$(git config --global user.email)" = "" ] && echo "Configuring global git user email." && git config --global user.email "robot@example.com"
+
+echo "==> Prepare source repo"
+if [ ! -d "${SRC_REPO_URL}" ]; then
+  echo "    Clone source repo into directory ${REPO_DIR}"
+  git clone "${SRC_REPO_URL}" "${REPO_DIR}" || true
+else
+  echo "    Using existing source repo in directory ${REPO_DIR}"
+fi
+
+echo "    Create ${VERSION} branch."
+git checkout -b "${VERSION}" || true
+
+echo "    Remove all files from the repo directory to copy the latest files."
+rm -Rf "${REPO_DIR:?}"/*
+
+echo "==> Copy latest source files."
+cp -Rf "${SRC_DIR}"/* "${REPO_DIR}"
+
+curdir=$PWD
+cd "${REPO_DIR}"
+echo "==> Create ${VERSION} version."
+# Always create the dev version.
+echo "    Update development ${VERSION_DEV} version."
+mike deploy --update-aliases "${VERSION_DEV}"
+if [ "${VERSION}" != "${VERSION_DEV}" ]; then
+  echo "    Create release ${VERSION} version."
+  mike deploy "${VERSION}"
+  echo "    Set ${VERSION} as the ${VERSION_LATEST} version."
+  mike set-default "${VERSION}"
+  mike alias --update-aliases "${VERSION}" "${VERSION_LATEST}"
+fi
+cd "$curdir"
+
+echo "==> Clean up."
+echo "    Prepare the clean repo directory."
+rm -Rf "${REPO_DIR_CLEAN}" || true
+echo "    Copy repo into the clean repo directory."
+git clone "${REPO_DIR}" "${REPO_DIR_CLEAN}"
+echo "    Switch to the 'gh-pages' branch."
+git --git-dir="${REPO_DIR_CLEAN}/.git" --work-tree="${REPO_DIR_CLEAN}" checkout gh-pages
+
+echo "==> Copy content to the output directory."
+echo "    Prepare output directory."
+mkdir -p "${OUTPUT_DIR}"
+rm -Rf "${OUTPUT_DIR:?}"/*
+echo "    Copy built files into the output directory."
+cp -Rf "${REPO_DIR_CLEAN:?}"/* "${OUTPUT_DIR}"
+echo "    Copy CNAME from the source directory into the output directory."
+cp "${SRC_DIR}/CNAME" "${OUTPUT_DIR}" || true
+
+echo "Finished release."
+echo "    Version:        ${VERSION}"
+echo "    REPO_DIR:       ${REPO_DIR}"
+echo "    REPO_DIR_CLEAN: ${REPO_DIR_CLEAN}"
+echo "    OUTPUT_DIR:     ${OUTPUT_DIR}"

--- a/scripts/drevops/docs/maintenance/updating-documentation.md
+++ b/scripts/drevops/docs/maintenance/updating-documentation.md
@@ -1,0 +1,5 @@
+# Updating documentation
+
+!!! note "Work in progress"
+
+    The documentation section is still a work in progress.

--- a/scripts/drevops/docs/mkdocs.yml
+++ b/scripts/drevops/docs/mkdocs.yml
@@ -85,6 +85,9 @@ plugins:
         - rel_to_abs: # Pattern name, can be anything
             oldvalue: "../../../../"
             newvalue: "https://github.com/drevops/drevops/tree/main/"
+  - mike:
+      version_selector: true
+
 ## Customization
 extra:
   social:
@@ -100,6 +103,8 @@ extra:
       as to measure the effectiveness of our documentation and whether users
       find what they're searching for. With your consent, you're helping us to
       make our documentation better.
+  version:
+    provider: mike
 
 # Extensions
 markdown_extensions:
@@ -150,3 +155,4 @@ nav:
   - Maintenance:
     - Authoring scripts: maintenance/authoring-scripts.md
     - Updating test assets: maintenance/updating-test-assets.md
+    - Updating documentation: maintenance/updating-documentation.md


### PR DESCRIPTION
Docs are published to:
- `dev` when merged to `main`
- `{branch-name-hyphenated}` when source branch contains `docs` substring
- `{version}` on release; `latest` is symlinked to the release as well.

<img width="1271" alt="Cursor_and_Updating_documentation_-_DrevOps" src="https://user-images.githubusercontent.com/378794/233581793-d59a5056-b643-4935-b422-a698b2241ca2.png">
