### PR TITLE
chore: Updated scripts to use full drush commands and improved site install information.

### DIFF
--- a/drush/drushrc.php
+++ b/drush/drushrc.php
@@ -8,7 +8,7 @@
 // Skip data for some tables during sql dumps and syncs
 // These tables will be syncronized just as structure and not the data inside
 // them, this makes syncing and dumping much faster
-// In case you need these tables, call the 'sql-sync' or 'sql-dump' command
+// In case you need these tables, call the 'sql-sync' or 'sql:dump' command
 // with '--no-structure-tables-list'.
 $command_specific['sql-sync'] = ['structure-tables-list' => 'cache,cache_*,history,sessions,watchdog,feeds_log'];
 $command_specific['sql-dump'] = ['structure-tables-list' => 'cache,cache_*,history,sessions,watchdog,feeds_log'];

--- a/scripts/drevops/docs/maintenance/authoring-scripts.md
+++ b/scripts/drevops/docs/maintenance/authoring-scripts.md
@@ -52,23 +52,24 @@ command -v curl > /dev/null || ( fail "curl command is not available." && exit 1
 ```bash
 info "Started GitHub notification for operation ${DREVOPS_NOTIFY_EVENT}"
 ```
-8. MUST contain an `pass` message about the finish of the script body, e.g.:
+10. MUST contain an `pass` message about the finish of the script body, e.g.:
 ```bash
 pass "Finished GitHub notification for operation ${DREVOPS_NOTIFY_EVENT}"
 ```
-9. MUST use uppercase global variables
-10. MUST use lowercase local variables.
-11. MUST use `DREVOPS_` prefix for variables, unless it is a known 3-rd party
+11. MUST use uppercase global variables
+12. MUST use lowercase local variables.
+13. MUST use long options instead of short options for readability. I.e., `drush cache:rebuild` instead of `drush cr`.
+14. MUST use `DREVOPS_` prefix for variables, unless it is a known 3-rd party
     variable like `GITHUB_TOKEN` or `COMPOSER`.
-12. MUST use script-specific prefix. I.e., for `notify.sh`, the variable to skip
+15. MUST use script-specific prefix. I.e., for `notify.sh`, the variable to skip
     notifications should start with `DREVOPS_NOTIFY_`.
-13. MAY rely on variables from the external scripts (not prefixed with a
+16. MAY rely on variables from the external scripts (not prefixed with a
     script-specific prefix), but MUST declare such variables in the header of
     the file.
-14. MAY call other DrevOps scripts (discouraged), but MUST source them rather
+17. MAY call other DrevOps scripts (discouraged), but MUST source them rather
     than creating a sub-process. This is to allow passing environment variables
     down the call stack.
-10. SHOULD use `note` messages for informing about the script progress.
+18. SHOULD use `note` messages for informing about the script progress.
 
 ## Scaffold script
 

--- a/scripts/drevops/download-db-lagoon.sh
+++ b/scripts/drevops/download-db-lagoon.sh
@@ -121,7 +121,7 @@ ssh \
   "if [ ! -f \"${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\" ] || [ \"${DREVOPS_DB_DOWNLOAD_REFRESH}\" == \"1\" ] ; then \
      [ -n \"${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE_CLEANUP}\" ] && rm -f \"${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}\"\/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE_CLEANUP} && echo \"Removed previously created DB dumps.\"; \
      echo \"      > Creating a backup ${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE}.\"; \
-     /app/vendor/bin/drush --root=${DREVOPS_APP}/${DREVOPS_WEBROOT} sql-dump --structure-tables-key=common --structure-tables-list=ban,event_log_track,flood,login_security_track,purge_queue,queue,webform_submission,webform_submission_data,webform_submission_log,cache* --extra-dump=--no-tablespaces > \"${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\"; \
+     /app/vendor/bin/drush --root=${DREVOPS_APP}/${DREVOPS_WEBROOT} sql:dump --structure-tables-key=common --structure-tables-list=ban,event_log_track,flood,login_security_track,purge_queue,queue,webform_submission,webform_submission_data,webform_submission_log,watchdog,cache* --extra-dump=--no-tablespaces > \"${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE}\"; \
    else \
      echo \"      > Using existing dump ${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_DIR}/${DREVOPS_DB_DOWNLOAD_LAGOON_REMOTE_FILE}.\"; \
    fi"

--- a/scripts/drevops/drupal-login.sh
+++ b/scripts/drevops/drupal-login.sh
@@ -22,9 +22,9 @@ drush="$(if [ -f "${DREVOPS_APP}/vendor/bin/drush" ]; then echo "${DREVOPS_APP}/
 
 if [ "${DREVOPS_DRUPAL_LOGIN_UNBLOCK_ADMIN}" = "1" ]; then
   if $drush pm:list --status=enabled | grep -q user_expire; then
-    $drush -q sqlq "UPDATE \`user__field_password_expiration\` SET \`field_password_expiration_value\` = 0 WHERE \`bundle\` = \"user\" AND \`entity_id\` = 1;"
+    $drush -q sql:query "UPDATE \`user__field_password_expiration\` SET \`field_password_expiration_value\` = 0 WHERE \`bundle\` = \"user\" AND \`entity_id\` = 1;"
   fi
-  $drush sqlq "SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" | head -n 1 | xargs $drush -q -- uublk
+  $drush sql:query "SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" | head -n 1 | xargs $drush -q -- user:unblock
 fi
 
-$drush uli
+$drush user:login

--- a/scripts/drevops/drupal-logout.sh
+++ b/scripts/drevops/drupal-logout.sh
@@ -21,5 +21,5 @@ DREVOPS_DRUPAL_LOGIN_UNBLOCK_ADMIN="${DREVOPS_DRUPAL_LOGIN_UNBLOCK_ADMIN:-1}"
 drush="$(if [ -f "${DREVOPS_APP}/vendor/bin/drush" ]; then echo "${DREVOPS_APP}/vendor/bin/drush"; else command -v drush; fi)"
 
 if [ "${DREVOPS_DRUPAL_LOGIN_UNBLOCK_ADMIN}" = "1" ]; then
-  $drush sqlq "SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" | head -n 1 | xargs $drush -q -- ublk
+  $drush sql:query "SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" | head -n 1 | xargs $drush -q -- user:block
 fi

--- a/scripts/drevops/drupal-sanitize-db.sh
+++ b/scripts/drevops/drupal-sanitize-db.sh
@@ -43,8 +43,8 @@ drush_opts=(-y)
 [ -z "${DREVOPS_DEBUG:-}" ] && drush_opts+=(-q)
 
 # Always sanitize password and email using standard methods.
-$drush "${drush_opts[@]}" sql-sanitize --sanitize-password="${DREVOPS_DRUPAL_DB_SANITIZE_PASSWORD}" --sanitize-email="${DREVOPS_DRUPAL_DB_SANITIZE_EMAIL}"
-pass "Sanitized database using drush sql-sanitize."
+$drush "${drush_opts[@]}" sql:sanitize --sanitize-password="${DREVOPS_DRUPAL_DB_SANITIZE_PASSWORD}" --sanitize-email="${DREVOPS_DRUPAL_DB_SANITIZE_EMAIL}"
+pass "Sanitized database using drush sql:sanitize."
 
 if [ "${DREVOPS_DRUPAL_DB_SANITIZE_REPLACE_USERNAME_WITH_EMAIL}" = "1" ]; then
   $drush sql:query "UPDATE \`users_field_data\` set users_field_data.name=users_field_data.mail WHERE uid <> '0';"

--- a/scripts/drevops/drupal-sanitize-db.sh
+++ b/scripts/drevops/drupal-sanitize-db.sh
@@ -47,25 +47,25 @@ $drush "${drush_opts[@]}" sql-sanitize --sanitize-password="${DREVOPS_DRUPAL_DB_
 pass "Sanitized database using drush sql-sanitize."
 
 if [ "${DREVOPS_DRUPAL_DB_SANITIZE_REPLACE_USERNAME_WITH_EMAIL}" = "1" ]; then
-  $drush sql-query "UPDATE \`users_field_data\` set users_field_data.name=users_field_data.mail WHERE uid <> '0';"
+  $drush sql:query "UPDATE \`users_field_data\` set users_field_data.name=users_field_data.mail WHERE uid <> '0';"
   pass "Updated username with user email."
 fi
 
 # Sanitize using additional SQL commands provided in file.
 # To skip custom sanitization, remove the DREVOPS_DRUPAL_DB_SANITIZE_ADDITIONAL_FILE file from the codebase.
 if [ -f "${DREVOPS_DRUPAL_DB_SANITIZE_ADDITIONAL_FILE}" ]; then
-  $drush "${drush_opts[@]}" sql-query --file="${DREVOPS_DRUPAL_DB_SANITIZE_ADDITIONAL_FILE}"
+  $drush "${drush_opts[@]}" sql:query --file="${DREVOPS_DRUPAL_DB_SANITIZE_ADDITIONAL_FILE}"
   pass "Applied custom sanitization commands."
 fi
 
 # User mail and name for use 0 could have been sanitized - resetting it.
-$drush "${drush_opts[@]}" sql-query "UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';"
-$drush "${drush_opts[@]}" sql-query "UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';"
+$drush "${drush_opts[@]}" sql:query "UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';"
+$drush "${drush_opts[@]}" sql:query "UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';"
 pass "Reset user 0 username and email."
 
 # User email could have been sanitized - setting it back to a pre-defined email.
 if [ -n "${DREVOPS_DRUPAL_ADMIN_EMAIL:-}" ]; then
-  $drush "${drush_opts[@]}" sql-query "UPDATE \`users_field_data\` SET mail = '${DREVOPS_DRUPAL_ADMIN_EMAIL:-}' WHERE uid = '1';"
+  $drush "${drush_opts[@]}" sql:query "UPDATE \`users_field_data\` SET mail = '${DREVOPS_DRUPAL_ADMIN_EMAIL:-}' WHERE uid = '1';"
   pass "Updated user 1 email."
 fi
 

--- a/scripts/drevops/export-db-file.sh
+++ b/scripts/drevops/export-db-file.sh
@@ -39,7 +39,7 @@ dump_file=$([ "${1}" ] && echo "${DREVOPS_DB_EXPORT_FILE_DIR}/${1}" || echo "${D
 # Dump database into a file. Also, convert relative path to an absolute one, as
 # the result file is relative to Drupal root, but provided paths are relative
 # to the project root.
-$drush sql-dump --skip-tables-key=common --extra-dump=--no-tablespaces --result-file="${dump_file/.\//${DREVOPS_APP}/}" -q
+$drush sql:dump --skip-tables-key=common --extra-dump=--no-tablespaces --result-file="${dump_file/.\//${DREVOPS_APP}/}" -q
 
 # Check that file was saved and output saved dump file name.
 if [ -f "${dump_file}" ] && [ -s "${dump_file}" ]; then

--- a/scripts/drevops/tests/bats/drupal_install_site.bats
+++ b/scripts/drevops/tests/bats/drupal_install_site.bats
@@ -148,8 +148,8 @@ assert_drupal_install_site_info(){
 
   # Sanitization is skipped for the existing database.
   assert_output_contains "Sanitizing database."
-  assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
-  assert_output_contains "Sanitized database using drush sql-sanitize."
+  assert_equal "-y -q sql:sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
+  assert_output_contains "Sanitized database using drush sql:sanitize."
   assert_output_not_contains "Updated username with user email."
   assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
   assert_output_contains "Applied custom sanitization commands."
@@ -280,7 +280,7 @@ assert_drupal_install_site_info(){
   # Sanitization is skipped for the existing database.
   assert_output_contains "Skipped database sanitization."
   assert_output_not_contains "Sanitizing database."
-  assert_output_not_contains "Sanitized database using drush sql-sanitize."
+  assert_output_not_contains "Sanitized database using drush sql:sanitize."
   assert_output_not_contains "Updated username with user email."
   assert_output_not_contains "Applied custom sanitization commands from file "
   assert_output_not_contains "Reset user 0 username and email."
@@ -419,8 +419,8 @@ assert_drupal_install_site_info(){
   assert_equal "list" "$(mock_get_call_args "${mock_drush}" 10)"
 
   assert_output_contains "Sanitizing database."
-  assert_output_contains "Sanitized database using drush sql-sanitize."
-  assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
+  assert_output_contains "Sanitized database using drush sql:sanitize."
+  assert_equal "-y -q sql:sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
   assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
@@ -564,8 +564,8 @@ assert_drupal_install_site_info(){
   assert_equal "list" "$(mock_get_call_args "${mock_drush}" 10)"
 
   assert_output_contains "Sanitizing database."
-  assert_output_contains "Sanitized database using drush sql-sanitize."
-  assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
+  assert_output_contains "Sanitized database using drush sql:sanitize."
+  assert_equal "-y -q sql:sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
   assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
@@ -694,7 +694,7 @@ assert_drupal_install_site_info(){
   # Sanitization is skipped for the existing database.
   assert_output_contains "Skipped database sanitization."
   assert_output_not_contains "Sanitizing database."
-  assert_output_not_contains "Sanitized database using drush sql-sanitize."
+  assert_output_not_contains "Sanitized database using drush sql:sanitize."
   assert_output_not_contains "Updated username with user email."
   assert_output_not_contains "Applied custom sanitization commands from file "
   assert_output_not_contains "Reset user 0 username and email."
@@ -830,8 +830,8 @@ assert_drupal_install_site_info(){
   assert_equal "list" "$(mock_get_call_args "${mock_drush}" 10)"
 
   assert_output_contains "Sanitizing database."
-  assert_output_contains "Sanitized database using drush sql-sanitize."
-  assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
+  assert_output_contains "Sanitized database using drush sql:sanitize."
+  assert_equal "-y -q sql:sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
   assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"

--- a/scripts/drevops/tests/bats/drupal_install_site.bats
+++ b/scripts/drevops/tests/bats/drupal_install_site.bats
@@ -6,6 +6,10 @@
 
 load _helper.bash
 
+format_yes_no() {
+  [ "${1}" == "1" ] && echo "Yes" || echo "No"
+}
+
 assert_drupal_install_site_info(){
   local webroot="${8:-web}"
 
@@ -15,19 +19,21 @@ assert_drupal_install_site_info(){
   assert_output_contains "Site name                    : Example site"
   assert_output_contains "Site email                   : webmaster@example.com"
   assert_output_contains "Profile                      : standard"
-  assert_output_contains "Install from profile         : ${1:-0}"
-  assert_output_contains "Overwrite existing DB        : ${2:-0}"
-  assert_output_contains "Skip sanitization            : ${3:-0}"
-  assert_output_contains "Use maintenance mode         : ${4:-1}"
-  assert_output_contains "Skip post-install operations : ${5:-0}"
   assert_output_contains "Private files directory      : ${LOCAL_REPO_DIR}/${webroot}/sites/default/files/private"
   assert_output_contains "Config path                  : ${LOCAL_REPO_DIR}/config/default"
   assert_output_contains "DB dump file path            : ${LOCAL_REPO_DIR}/.data/db.sql"
-  assert_output_contains "Existing site found          : ${6:-0}"
-  assert_output_contains "Configuration files present  : ${7:-0}"
+
   assert_output_contains "Drush binary                 :"
   assert_output_contains "Drush version                :"
   assert_output_contains "Drupal core version          :"
+
+  assert_output_contains "Install from profile         : $(format_yes_no "${1:-0}")"
+  assert_output_contains "Overwrite existing DB        : $(format_yes_no "${2:-0}")"
+  assert_output_contains "Skip sanitization            : $(format_yes_no "${3:-0}")"
+  assert_output_contains "Use maintenance mode         : $(format_yes_no "${4:-1}")"
+  assert_output_contains "Skip post-install operations : $(format_yes_no "${5:-0}")"
+  assert_output_contains "Configuration files present  : $(format_yes_no "${6:-0}")"
+  assert_output_contains "Existing site found          : $(format_yes_no "${7:-0}")"
 }
 
 @test "Site install: DB; no site" {
@@ -96,13 +102,13 @@ assert_drupal_install_site_info(){
   assert_output_contains "Created private files directory."
 
   assert_output_contains "Installing site from the database dump file."
-  assert_output_contains "Dump file: ${LOCAL_REPO_DIR}/.data/db.sql"
+  assert_output_contains "Dump file path: ${LOCAL_REPO_DIR}/.data/db.sql"
   assert_output_contains "Existing site was not found."
   assert_output_contains "The site content will be imported from the database dump file."
   assert_output_contains "Imported database from the dump file."
 
-  assert_equal "-y -q sql-drop" "$(mock_get_call_args "${mock_drush}" 4)"
-  assert_equal "-y -q sqlc" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y -q sql:drop" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "-y -q sql:cli" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_not_contains "Unable to import database from file."
   assert_output_not_contains "Dump file ${LOCAL_REPO_DIR}/.data/db.sql does not exist."
@@ -123,7 +129,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -145,10 +151,10 @@ assert_drupal_install_site_info(){
   assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_contains "Sanitized database using drush sql-sanitize."
   assert_output_not_contains "Updated username with user email."
-  assert_equal "-y -q sql-query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
+  assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
   assert_output_contains "Applied custom sanitization commands."
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
   assert_output_contains "Reset user 0 username and email."
   assert_output_not_contains "Updated user 1 email."
   assert_output_not_contains "Skipped database sanitization."
@@ -167,9 +173,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 20)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 22)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 23)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 22)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 23)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."
@@ -228,13 +234,13 @@ assert_drupal_install_site_info(){
 
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
 
-  assert_drupal_install_site_info 0 0 0 1 0 1 0
+  assert_drupal_install_site_info 0 0 0 1 0 0 1
 
   assert_output_contains "Creating private files directory."
   assert_output_contains "Created private files directory."
 
   assert_output_contains "Installing site from the database dump file."
-  assert_output_contains "Dump file: ${LOCAL_REPO_DIR}/.data/db.sql"
+  assert_output_contains "Dump file path: ${LOCAL_REPO_DIR}/.data/db.sql"
   assert_output_contains "Existing site was found."
   assert_output_contains "Site content will be preserved."
   assert_output_contains "Sanitization will be skipped for an existing database."
@@ -254,7 +260,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -294,9 +300,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 14)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 15)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 16)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 17)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 15)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 16)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 17)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."
@@ -366,19 +372,19 @@ assert_drupal_install_site_info(){
 
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
 
-  assert_drupal_install_site_info 0 1 0 1 0 1 0
+  assert_drupal_install_site_info 0 1 0 1 0 0 1
 
   assert_output_contains "Creating private files directory."
   assert_output_contains "Created private files directory."
 
   assert_output_contains "Installing site from the database dump file."
-  assert_output_contains "Dump file: ${LOCAL_REPO_DIR}/.data/db.sql"
+  assert_output_contains "Dump file path: ${LOCAL_REPO_DIR}/.data/db.sql"
   assert_output_contains "Existing site was found."
   assert_output_contains "Existing site content will be removed and new content will be imported from the database dump file."
   assert_output_contains "Imported database from the dump file."
 
-  assert_equal "-y -q sql-drop" "$(mock_get_call_args "${mock_drush}" 4)"
-  assert_equal "-y -q sqlc" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y -q sql:drop" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "-y -q sql:cli" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_not_contains "Site content will be preserved."
   assert_output_not_contains "Sanitization will be skipped for an existing database."
@@ -395,7 +401,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -417,10 +423,10 @@ assert_drupal_install_site_info(){
   assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
-  assert_equal "-y -q sql-query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
+  assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
   assert_output_contains "Reset user 0 username and email."
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
   assert_output_not_contains "Updated user 1 email."
   assert_output_not_contains "Skipped database sanitization."
 
@@ -438,9 +444,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 20)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 22)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 23)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 22)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 23)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."
@@ -517,8 +523,8 @@ assert_drupal_install_site_info(){
   assert_output_contains "The site content will be created from the profile."
   assert_output_contains "Installed a site from the profile."
 
-  assert_equal "-y -q sql-drop" "$(mock_get_call_args "${mock_drush}" 4)"
-  assert_equal "si -q -y standard --site-name=Example site --site-mail=webmaster@example.com --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y -q sql:drop" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "site:install -q -y standard --site-name=Example site --site-mail=webmaster@example.com --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_not_contains "[FAIL] Unable to import database from file."
   assert_output_not_contains "Dump file ${LOCAL_REPO_DIR}/.data/db.sql does not exist."
@@ -540,7 +546,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -562,10 +568,10 @@ assert_drupal_install_site_info(){
   assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
-  assert_equal "-y -q sql-query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
+  assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
   assert_output_contains "Reset user 0 username and email."
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
   assert_output_not_contains "Updated user 1 email."
   assert_output_not_contains "Skipped database sanitization."
 
@@ -583,9 +589,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 20)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 22)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 23)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 22)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 23)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."
@@ -642,7 +648,7 @@ assert_drupal_install_site_info(){
 
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
 
-  assert_drupal_install_site_info 1 0 0 1 0 1 0
+  assert_drupal_install_site_info 1 0 0 1 0 0 1
 
   assert_output_contains "Creating private files directory."
   assert_output_contains "Created private files directory."
@@ -668,7 +674,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -708,9 +714,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 14)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 15)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 16)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 17)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 15)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 16)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 17)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."
@@ -777,7 +783,7 @@ assert_drupal_install_site_info(){
 
   assert_equal "status --fields=bootstrap" "$(mock_get_call_args "${mock_drush}" 3)"
 
-  assert_drupal_install_site_info 1 1 0 1 0 1 0
+  assert_drupal_install_site_info 1 1 0 1 0 0 1
 
   assert_output_contains "Creating private files directory."
   assert_output_contains "Created private files directory."
@@ -788,8 +794,8 @@ assert_drupal_install_site_info(){
   assert_output_contains "Existing site content will be removed and new content will be created from the profile."
   assert_output_contains "Installed a site from the profile."
 
-  assert_equal "-y -q sql-drop" "$(mock_get_call_args "${mock_drush}" 4)"
-  assert_equal "si -q -y standard --site-name=Example site --site-mail=webmaster@example.com --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL" "$(mock_get_call_args "${mock_drush}" 5)"
+  assert_equal "-y -q sql:drop" "$(mock_get_call_args "${mock_drush}" 4)"
+  assert_equal "site:install -q -y standard --site-name=Example site --site-mail=webmaster@example.com --account-name=admin install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL" "$(mock_get_call_args "${mock_drush}" 5)"
 
   assert_output_not_contains "Site content will be preserved."
   assert_output_not_contains "Sanitization will be skipped for an existing database."
@@ -806,7 +812,7 @@ assert_drupal_install_site_info(){
   assert_output_contains "Enabled maintenance mode."
 
   assert_output_contains "Running database updates."
-  assert_equal "-y updb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
+  assert_equal "-y updatedb --no-cache-clear" "$(mock_get_call_args "${mock_drush}" 7)"
 
   assert_output_contains "Importing Drupal configuration if it exists."
   assert_output_not_contains "Updated site UUID from the configuration with"
@@ -828,10 +834,10 @@ assert_drupal_install_site_info(){
   assert_equal "-y -q sql-sanitize --sanitize-password=MOCK_DB_SANITIZE_PASSWORD --sanitize-email=user+%uid@localhost" "$(mock_get_call_args "${mock_drush}" 11)"
   assert_output_not_contains "Updated username with user email."
   assert_output_contains "Applied custom sanitization commands."
-  assert_equal "-y -q sql-query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
+  assert_equal "-y -q sql:query --file=${LOCAL_REPO_DIR}/scripts/sanitize.sql" "$(mock_get_call_args "${mock_drush}" 12)"
   assert_output_contains "Reset user 0 username and email."
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
-  assert_equal "-y -q sql-query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET mail = '', name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 13)"
+  assert_equal "-y -q sql:query UPDATE \`users_field_data\` SET name = '' WHERE uid = '0';" "$(mock_get_call_args "${mock_drush}" 14)"
   assert_output_not_contains "Updated user 1 email."
   assert_output_not_contains "Skipped database sanitization."
 
@@ -849,9 +855,9 @@ assert_drupal_install_site_info(){
 
   # One-time login link.
   assert_equal "pm:list --status=enabled" "$(mock_get_call_args "${mock_drush}" 20)"
-  assert_equal "sqlq SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
-  assert_equal "-q -- uublk admin" "$(mock_get_call_args "${mock_drush}" 22)"
-  assert_equal "uli" "$(mock_get_call_args "${mock_drush}" 23)"
+  assert_equal "sql:query SELECT name FROM \`users_field_data\` WHERE \`uid\` = '1';" "$(mock_get_call_args "${mock_drush}" 21)"
+  assert_equal "-q -- user:unblock admin" "$(mock_get_call_args "${mock_drush}" 22)"
+  assert_equal "user:login" "$(mock_get_call_args "${mock_drush}" 23)"
   assert_output_contains "MOCK_ONE_TIME_LINK"
 
   assert_output_contains "Finished site installation."


### PR DESCRIPTION
- Updated drush commands to use the full notation.
- Updated installation summary:
```
[INFO] Started site installation.

       App dir                      : /app
       Web root dir                 : web
       Site name                    : YOURSITE
       Site email                   : webmaster@your-site-url.example
       Profile                      : your_site_profile
       Private files directory      : /app/web/sites/default/files/private
       Config path                  : /app/config/default
       DB dump file path            : /app/.data/db.sql (present)

       Drush binary                 : /app/vendor/bin/drush
       Drush version                : Drush Commandline Tool 11.5.1
       Drupal core version          : 10.0.9

       Install from profile         : No
       Overwrite existing DB        : No
       Skip sanitization            : No
       Use maintenance mode         : Yes
       Skip post-install operations : No
       Configuration files present  : No
       Existing site found          : Yes
```