### PR TITLE
Updated CI to use the default Docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ aliases:
   - &step_setup_remote_docker
     setup_remote_docker:
       docker_layer_caching: *docker_layer_caching
-      version: 20.10.18
+      version: default
 
   # Set up Docker network.
   - &step_setup_docker_network


### PR DESCRIPTION
See https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176
