### PR TITLE
[#1175] Show DrevOps variables in Lagoon only when $DREVOPS_DEBUG is set.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -15,7 +15,8 @@ tasks:
   post-rollout:
     - run:
         name: Show DrevOps variables.
-        command: env -0  | sort -z | tr '\0' '\n' | grep ^DREVOPS_ || true
+        command: |
+          [ "${DREVOPS_DEBUG-}" = "1" ] && env -0  | sort -z | tr '\0' '\n' | grep ^DREVOPS_ || true
         service: cli
         shell: bash
 


### PR DESCRIPTION
closes #1175